### PR TITLE
[14.0][FIX] front_office_management: use raw id for visitor kanban image

### DIFF
--- a/front_office_management/views/fo_visitor.xml
+++ b/front_office_management/views/fo_visitor.xml
@@ -106,7 +106,7 @@
                             <div class="oe_kanban_global_click">
                                 <div class="o_kanban_image">
                                     <img
-                    t-att-src="kanban_image('fo.visitor', 'visitor_image', record.id.value)"
+                    t-att-src="kanban_image('fo.visitor', 'visitor_image', record.id.raw_value)"
                     alt="Visitor Image"
                   />
                                 </div>


### PR DESCRIPTION
## Cause

The visitor kanban image URL used `record.id.value` in `kanban_image(...)`.
In Odoo 14 this can serialize the id as a decimal-like value, which reaches
`/web/image` as a non-integer id and raises a fast 500.

## Change

Use `record.id.raw_value`, matching the standard Odoo 14 kanban image pattern.

## Validation

- Functional local validation by Eric on Guijarron 14: visitor kanban works.
- `xmllint --noout front_office_management/views/fo_visitor.xml`
- `git diff --check 14.0..HEAD`
- Odoo Guidelines review: title, commit, branch, and scope are compliant.
- `pre-commit run --files front_office_management/views/fo_visitor.xml` was attempted but the repository configuration fails before running hooks while initializing the legacy `https://gitlab.com/pycqa/flake8` hook. The relevant XML/manual checks above pass.

Task: #2663